### PR TITLE
fix: use fileDependencies to support webpack5

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ class HtmlWebpackPlugin {
       compilation.hooks.additionalChunkAssets.tap('HtmlWebpackPlugin', () => {
         const childCompilerDependencies = childCompiler.getFileDependencies(compiler);
         childCompilerDependencies.forEach(fileDependency => {
-          compilation.compilationDependencies.add(fileDependency);
+          compilation.fileDependencies.add(fileDependency);
         });
       });
     });


### PR DESCRIPTION
It seems that `compilationDependencies` is not supported in webpack 5. Need to change it to fileDependencies.